### PR TITLE
Enhance customisation of eml_file provider

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,12 @@ are used for versioning (schema follows below):
   0.3.4 to 0.4).
 - All backwards incompatible changes are mentioned in this document.
 
+0.18.4
+------
+2025-05-09
+
+- Enhance customisation of ``eml_file`` provider.
+
 0.18.3
 ------
 2025-05-07

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean_up another_script
 
 # Update version ONLY here
-VERSION := 0.18.3
+VERSION := 0.18.4
 
 alembic-migrate:
 	cd examples/sqlalchemy_example/faker_file_admin/ && alembic upgrade head

--- a/docs/_static/examples/recipes/eml_file_5.py
+++ b/docs/_static/examples/recipes/eml_file_5.py
@@ -1,0 +1,31 @@
+from faker import Faker
+from faker_file.providers.eml_file import EmlFileProvider
+from faker_file.providers.helpers.inner import (
+    create_inner_docx_file,
+    create_inner_epub_file,
+    create_inner_txt_file,
+    fuzzy_choice_create_inner_file,
+)
+from faker_file.storages.filesystem import FileSystemStorage
+
+FAKER = Faker()
+FAKER.add_provider(EmlFileProvider)
+
+STORAGE = FileSystemStorage()
+
+kwargs = {"storage": STORAGE, "generator": FAKER}
+
+eml_file = FAKER.eml_file(
+    cte_type="7bit",
+    options={
+        "count": 10,
+        "create_inner_file_func": fuzzy_choice_create_inner_file,
+        "create_inner_file_args": {
+            "func_choices": [
+                (create_inner_docx_file, kwargs),
+                (create_inner_epub_file, kwargs),
+                (create_inner_txt_file, kwargs),
+            ],
+        },
+    },
+)

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -234,6 +234,21 @@ Create an EML file with variety of different file types within
     *See the full example*
     :download:`here <_static/examples/recipes/eml_file_4.py>`
 
+Create an EML file ``Content-Transfer-Encoding`` set to ``7bit``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- 10 files in the EML file (limited to DOCX, EPUB and TXT types).
+- Content is generated dynamically.
+- Set the ``Content-Transfer-Encoding`` to ``7bit``.
+
+.. container:: jsphinx-download
+
+    .. literalinclude:: _static/examples/recipes/eml_file_5.py
+        :language: python
+        :lines: 3-8, 17-
+
+    *See the full example*
+    :download:`here <_static/examples/recipes/eml_file_5.py>`
+
 Create a PDF file with predefined template containing dynamic fixtures
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - Content template is predefined and contains dynamic fixtures.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def clean_readme(text: str) -> str:
     return text
 
 
-version = "0.18.3"
+version = "0.18.4"
 
 try:
     readme_path = Path(__file__).parent / "README.rst"

--- a/src/faker_file/__init__.py
+++ b/src/faker_file/__init__.py
@@ -1,5 +1,5 @@
 __title__ = "faker_file"
-__version__ = "0.18.3"
+__version__ = "0.18.4"
 __author__ = "Artur Barseghyan <artur.barseghyan@gmail.com>"
 __copyright__ = "2022-2025 Artur Barseghyan"
 __license__ = "MIT"

--- a/src/faker_file/providers/helpers/inner.py
+++ b/src/faker_file/providers/helpers/inner.py
@@ -1,3 +1,4 @@
+from email.policy import Policy
 from random import choice
 from typing import (
     Any,
@@ -464,6 +465,8 @@ def create_inner_eml_file(
     max_nb_chars: int = DEFAULT_TEXT_MAX_NB_CHARS,
     wrap_chars_after: Optional[int] = None,
     content: Optional[str] = None,
+    cte_type: Optional[str] = None,
+    policy: Optional[Policy] = None,
     format_func: Callable[
         [Union[Faker, Generator, Provider], str], str
     ] = DEFAULT_FORMAT_FUNC,
@@ -483,6 +486,8 @@ def create_inner_eml_file(
         max_nb_chars=max_nb_chars,
         wrap_chars_after=wrap_chars_after,
         content=content,
+        cte_type=cte_type,
+        policy=policy,
         format_func=format_func,
         raw=raw,
         **kwargs,


### PR DESCRIPTION
@martinburchell 

FYI.

```
from faker import Faker
from faker_file.providers.eml_file import EmlFileProvider
from faker_file.providers.helpers.inner import (
    create_inner_bin_file,
    create_inner_csv_file,
    create_inner_docx_file,
    create_inner_eml_file,
    create_inner_epub_file,
    create_inner_graphic_ico_file,
    create_inner_graphic_jpeg_file,
    create_inner_graphic_pdf_file,
    create_inner_graphic_png_file,
    create_inner_graphic_webp_file,
    create_inner_ico_file,
    create_inner_jpeg_file,
    create_inner_json_file,
    create_inner_mp3_file,
    create_inner_odp_file,
    create_inner_ods_file,
    create_inner_odt_file,
    create_inner_pdf_file,
    create_inner_png_file,
    create_inner_pptx_file,
    create_inner_rtf_file,
    create_inner_svg_file,
    create_inner_tar_file,
    create_inner_txt_file,
    create_inner_webp_file,
    create_inner_xlsx_file,
    create_inner_xml_file,
    create_inner_zip_file,
    list_create_inner_file,
)
from faker_file.storages.filesystem import FileSystemStorage

FAKER = Faker()
FAKER.add_provider(EmlFileProvider)

STORAGE = FileSystemStorage()

kwargs = {"storage": STORAGE, "generator": FAKER}

eml_file_7bit = FAKER.eml_file(
    prefix="7bit_",
    cte_type="7bit",
    options={
        "count": 10,
        "create_inner_file_func": list_create_inner_file,
        "create_inner_file_args": {
            "func_list": [
                (create_inner_bin_file, kwargs),
                (create_inner_csv_file, kwargs),
                (create_inner_docx_file, kwargs),
                (create_inner_eml_file, kwargs),
                (create_inner_epub_file, kwargs),
                (create_inner_graphic_ico_file, kwargs),
                (create_inner_graphic_jpeg_file, kwargs),
                (create_inner_graphic_pdf_file, kwargs),
                (create_inner_graphic_png_file, kwargs),
                (create_inner_graphic_webp_file, kwargs),
                (create_inner_ico_file, kwargs),
                (create_inner_jpeg_file, kwargs),
                (create_inner_json_file, kwargs),
                (create_inner_mp3_file, kwargs),
                (create_inner_odp_file, kwargs),
                (create_inner_ods_file, kwargs),
                (create_inner_odt_file, kwargs),
                (create_inner_pdf_file, kwargs),
                (create_inner_png_file, kwargs),
                (create_inner_pptx_file, kwargs),
                (create_inner_rtf_file, kwargs),
                (create_inner_svg_file, kwargs),
                (create_inner_tar_file, kwargs),
                (create_inner_txt_file, kwargs),
                (create_inner_webp_file, kwargs),
                (create_inner_xlsx_file, kwargs),
                (create_inner_xml_file, kwargs),
                (create_inner_zip_file, kwargs),
            ],
        },
    },
)
```