### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,7 +162,7 @@ jobs:
         #          - Windows
         #          - MacOs
         python-version:
-#          - "3.13"
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
@@ -177,8 +177,8 @@ jobs:
           - "0.10.3"
           - "0.11"
         exclude:
-#          - python-version: "3.13"
-#            pathy-version: "0.10.3"
+          - python-version: "3.13"
+            pathy-version: "0.10.3"
           - python-version: "3.12"
             pathy-version: "0.10.3"
           - python-version: "3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,8 +126,8 @@ exclude = [
 # Allow unused variables when underscore-prefixed.
 lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.9.
-target-version = "py39"
+# Assume Python 3.13.
+target-version = "py313"
 
 [tool.ruff.lint.per-file-ignores]
 "conftest.py" = [
@@ -161,7 +161,7 @@ stubPath = "src/stubs"
 reportMissingImports = true
 reportMissingTypeStubs = false
 
-pythonVersion = "3.10"
+pythonVersion = "3.13"
 pythonPlatform = "Linux"
 verboseOutput = true
 

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Environment :: Web Environment",
         "License :: OSI Approved :: MIT License",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
 ;    py{39,310,311}-django{42}
 ;    py{310,311}-django{50}
     py{39,310,311}-django{42,50}-pathy{0103,0110}
-    py312-django{42,50}-pathy0110
+    py{312,313}-django{42,50}-pathy0110
 
 [testenv]
 envlogdir={work_dir}/{env_name}/tmp
@@ -26,3 +26,4 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313


### PR DESCRIPTION
## Summary

This PR adds Python 3.13 support to faker-file.

## Changes

- **setup.py**: Added "Programming Language :: Python :: 3.13" classifier
- **.github/workflows/test.yml**: Enabled Python 3.13 in the test matrix with proper exclusions
- **tox.ini**: Added py313 to envlist and gh-actions mapping
- **pyproject.toml**: Updated target-version and pythonVersion to 3.13

## Testing

- Python 3.13 is now included in CI test matrix
- Python 3.13 + pathy 0.10.3 combination is excluded (incompatible)
- All other Python versions (3.9-3.13) tested with Django 4.2/5.0 and pathy 0.11.0

Fixes #108
